### PR TITLE
fix submodule path to current location of demo repository

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "demo"]
 	path = demo
-	url = git@github.com:ldesousa/pywps-4-demo.git
+	url = git@github.com:PyWPS/pywps-4-demo.git


### PR DESCRIPTION
The submodule pywps-4-demo.git was apparently moved from user  `ldesousa` to `PyWPS`. 
I changed to `.gitmodules` so it matches the current location. Don't forget to do a `git submodule sync demo` after this update. 
