### PR TITLE
make supported_formats/default_format/default formats consistent

### DIFF
--- a/pywps/inout/basic.py
+++ b/pywps/inout/basic.py
@@ -445,9 +445,9 @@ class ComplexOutput(BasicIO, BasicComplex, IOHandler):
     """
 
     def __init__(self, identifier, title=None, abstract=None,
-                 workdir=None, output_formats=None):
+                 workdir=None, data_formats=None):
         BasicIO.__init__(self, identifier, title, abstract)
-        BasicComplex.__init__(self, output_formats)
+        BasicComplex.__init__(self, data_formats)
         IOHandler.__init__(self, workdir)
 
         self._storage = None

--- a/pywps/inout/basic.py
+++ b/pywps/inout/basic.py
@@ -263,21 +263,23 @@ class BasicLiteral:
             data_type = LITERAL_DATA_TYPES[2]
         assert data_type in LITERAL_DATA_TYPES
         self.data_type = data_type
-        self.uoms = None
+        # list of uoms
+        self.uoms = []
+        # current uom
         self._uom = None
 
-        if self.uoms:
-            self.uom = self.uoms[0]
-
-        if uoms:
-            if type(uoms) is not type([]):
-                uoms = [uoms]
-
-            self.uoms = []
+        # add all uoms (upcasting to UOM)
+        if uoms is not None:
             for uom in uoms:
                 if not isinstance(uom, UOM):
                     uom = UOM(uom)
                 self.uoms.append(uom)
+
+        if self.uoms:
+            # default/current uom
+            self.uom = self.uoms[0]
+
+
 
     @property
     def uom(self):
@@ -293,8 +295,12 @@ class BasicComplex(object):
 
     """
 
-    def __init__(self, data_formats=None):
-        self.data_formats = data_formats
+    def __init__(self, supported_formats=None):
+        self.supported_formats = supported_formats
+        self._data_format = None
+        if self.supported_formats:
+            # not an empty list, set the default/current format to the first
+            self.data_format = supported_formats[0]
 
     @property
     def data_format(self):
@@ -316,7 +322,7 @@ class BasicComplex(object):
 
     def _is_supported(self, data_format):
 
-        for frmt in self.data_formats:
+        for frmt in self.supported_formats:
             if frmt.same_as(data_format):
                 return True
 
@@ -409,9 +415,9 @@ class ComplexInput(BasicIO, BasicComplex, IOHandler):
     """
 
     def __init__(self, identifier, title=None, abstract=None,
-                 workdir=None, data_formats=None):
+                 workdir=None, supported_formats=None):
         BasicIO.__init__(self, identifier, title, abstract)
-        BasicComplex.__init__(self, data_formats)
+        BasicComplex.__init__(self, supported_formats)
         IOHandler.__init__(self, workdir)
 
 
@@ -445,9 +451,9 @@ class ComplexOutput(BasicIO, BasicComplex, IOHandler):
     """
 
     def __init__(self, identifier, title=None, abstract=None,
-                 workdir=None, data_formats=None):
+                 workdir=None, supported_formats=None):
         BasicIO.__init__(self, identifier, title, abstract)
-        BasicComplex.__init__(self, data_formats)
+        BasicComplex.__init__(self, supported_formats)
         IOHandler.__init__(self, workdir)
 
         self._storage = None

--- a/pywps/inout/basic.py
+++ b/pywps/inout/basic.py
@@ -290,15 +290,11 @@ class BasicLiteral:
 
 class BasicComplex(object):
     """Basic complex input/output class
+
     """
 
-    def __init__(self, data_format=None, supported_formats=None):
-        self._data_format = None
-        self.supported_formats = supported_formats
-        if self.supported_formats:
-            self.data_format = supported_formats[0]
-        if data_format:
-            self.data_format = data_format
+    def __init__(self, data_formats=None):
+        self.data_formats = data_formats
 
     @property
     def data_format(self):
@@ -320,7 +316,7 @@ class BasicComplex(object):
 
     def _is_supported(self, data_format):
 
-        for frmt in self.supported_formats:
+        for frmt in self.data_formats:
             if frmt.same_as(data_format):
                 return True
 
@@ -413,9 +409,9 @@ class ComplexInput(BasicIO, BasicComplex, IOHandler):
     """
 
     def __init__(self, identifier, title=None, abstract=None,
-                 workdir=None, data_format=None, supported_formats=None):
+                 workdir=None, data_formats=None):
         BasicIO.__init__(self, identifier, title, abstract)
-        BasicComplex.__init__(self, data_format, supported_formats)
+        BasicComplex.__init__(self, data_formats)
         IOHandler.__init__(self, workdir)
 
 
@@ -449,9 +445,9 @@ class ComplexOutput(BasicIO, BasicComplex, IOHandler):
     """
 
     def __init__(self, identifier, title=None, abstract=None,
-                 workdir=None, data_format=None, supported_formats=None):
+                 workdir=None, output_formats=None):
         BasicIO.__init__(self, identifier, title, abstract)
-        BasicComplex.__init__(self, data_format, supported_formats)
+        BasicComplex.__init__(self, output_formats)
         IOHandler.__init__(self, workdir)
 
         self._storage = None

--- a/pywps/inout/formats.py
+++ b/pywps/inout/formats.py
@@ -83,8 +83,13 @@ class Format(object):
     def mime_type(self, mime_type):
         """Set format mime type
         """
-
-        self._mime_type = mime_type
+        try:
+            # support Format('GML')
+            formatdef = getattr(FORMATS, mime_type)
+            self._mime_type = formatdef.mime_type
+        except AttributeError:
+            # if we don't have this as a shortcut, assume it's a real mime type
+            self._mime_type = mime_type
 
     @property
     def encoding(self):

--- a/pywps/inout/inputs.py
+++ b/pywps/inout/inputs.py
@@ -10,8 +10,10 @@ class BoundingBoxInput(basic.BBoxInput):
     """
 
     def __init__(self, identifier, title, crss, abstract='',
-                 dimensions=2, metadata=[], min_occurs=1,
+                 dimensions=2, metadata=None, min_occurs=1,
                  max_occurs=1, as_reference=False):
+        if metadata is None:
+            metadata = []
         basic.BBoxInput.__init__(self, identifier, title=title,
                                  abstract=abstract, crss=crss,
                                  dimensions=dimensions)
@@ -87,9 +89,10 @@ class ComplexInput(basic.ComplexInput):
     """
 
     def __init__(self, identifier, title, supported_formats=None,
-                 abstract='', metadata=[], min_occurs=1,
+                 abstract='', metadata=None, min_occurs=1,
                  max_occurs=1, as_reference=False):
-
+        if metadata is None:
+            metadata = []
         basic.ComplexInput.__init__(self, identifier=identifier, title=title,
                                     abstract=abstract,
                                     supported_formats=supported_formats)

--- a/pywps/inout/inputs.py
+++ b/pywps/inout/inputs.py
@@ -86,13 +86,13 @@ class ComplexInput(basic.ComplexInput):
                     be the default. 
     """
 
-    def __init__(self, identifier, title, data_formats=None,
+    def __init__(self, identifier, title, supported_formats=None,
                  abstract='', metadata=[], min_occurs=1,
                  max_occurs=1, as_reference=False):
 
         basic.ComplexInput.__init__(self, identifier=identifier, title=title,
                                     abstract=abstract,
-                                    data_formats=data_formats)
+                                    supported_formats=supported_formats)
         self.metadata = metadata
         self.min_occurs = int(min_occurs)
         self.max_occurs = int(max_occurs)
@@ -113,8 +113,8 @@ class ComplexInput(basic.ComplexInput):
     def describe_xml(self):
         """Return Describe process element
         """
-        default_format_el = self.data_formats[0].describe_xml()
-        supported_format_elements = [f.describe_xml() for f in self.data_formats]
+        default_format_el = self.supported_formats[0].describe_xml()
+        supported_format_elements = [f.describe_xml() for f in self.supported_formats]
 
         doc = E.Input(
             OWS.Identifier(self.identifier),

--- a/pywps/inout/inputs.py
+++ b/pywps/inout/inputs.py
@@ -82,19 +82,17 @@ class ComplexInput(basic.ComplexInput):
     """
     :param identifier: The name of this input.
     :param allowed_formats: Allowed formats for this input. Should be a list of
-                    one or more :class:`~Format` objects.
-    :param data_format: Format of the passed input. Should be :class:`~Format` object
+                    one or more :class:`~Format` objects. First one is assumed to 
+                    be the default. 
     """
 
-    def __init__(self, identifier, title, supported_formats=None,
-                 data_format=None, abstract='', metadata=[], min_occurs=1,
+    def __init__(self, identifier, title, data_formats=None,
+                 abstract='', metadata=[], min_occurs=1,
                  max_occurs=1, as_reference=False):
 
         basic.ComplexInput.__init__(self, identifier=identifier, title=title,
                                     abstract=abstract,
-                                    data_format=data_format,
-                                    supported_formats=supported_formats)
-
+                                    data_formats=data_formats)
         self.metadata = metadata
         self.min_occurs = int(min_occurs)
         self.max_occurs = int(max_occurs)
@@ -115,8 +113,8 @@ class ComplexInput(basic.ComplexInput):
     def describe_xml(self):
         """Return Describe process element
         """
-        default_format_el = self.supported_formats[0].describe_xml()
-        supported_format_elements = [f.describe_xml() for f in self.supported_formats]
+        default_format_el = self.data_formats[0].describe_xml()
+        supported_format_elements = [f.describe_xml() for f in self.data_formats]
 
         doc = E.Input(
             OWS.Identifier(self.identifier),

--- a/pywps/inout/inputs.py
+++ b/pywps/inout/inputs.py
@@ -7,6 +7,7 @@ class BoundingBoxInput(basic.BBoxInput):
     """
     :param identifier: The name of this input.
     :param data_type: Type of literal input (e.g. `string`, `float`...).
+    :param crss: List of supported coordinate reference system (e.g. ['EPSG:4326'])
     """
 
     def __init__(self, identifier, title, crss, abstract='',

--- a/pywps/inout/outputs.py
+++ b/pywps/inout/outputs.py
@@ -76,19 +76,19 @@ class ComplexOutput(basic.ComplexOutput):
     """
     :param identifier: The name of this output.
     :param title: Readable form of the output name.
-    :param output_formats: List of supported
+    :param supported_formats: List of supported
             output formats for this output.
             Should be list of :class:`~Format` object.
             The first format in the list will be used as the default.
     :param abstract: Description of the output
     """
 
-    def __init__(self, identifier, title,  output_formats=None,
+    def __init__(self, identifier, title,  supported_formats=None,
                  abstract='', metadata=[]):
 
         basic.ComplexOutput.__init__(self, identifier, title=title,
                                      abstract=abstract,
-                                     output_formats=output_formats)
+                                     supported_formats=supported_formats)
         self.metadata = metadata
         self.as_reference = False
 

--- a/pywps/inout/outputs.py
+++ b/pywps/inout/outputs.py
@@ -12,8 +12,10 @@ class BoundingBoxOutput(basic.BBoxInput):
     """
 
     def __init__(self, identifier, title, crss, abstract='',
-                 dimensions=2, metadata=[], min_occurs='1',
+                 dimensions=2, metadata=None, min_occurs='1',
                  max_occurs='1', as_reference=False):
+        if metadata is None:
+            metadata = []
         basic.BBoxInput.__init__(self, identifier, title=title,
                                  abstract=abstract, crss=crss,
                                  dimensions=dimensions)
@@ -84,7 +86,9 @@ class ComplexOutput(basic.ComplexOutput):
     """
 
     def __init__(self, identifier, title,  supported_formats=None,
-                 abstract='', metadata=[]):
+                 abstract='', metadata=None):
+        if metadata is None:
+            metadata = []
 
         basic.ComplexOutput.__init__(self, identifier, title=title,
                                      abstract=abstract,
@@ -199,7 +203,11 @@ class LiteralOutput(basic.LiteralOutput):
     """
 
     def __init__(self, identifier, title, data_type='string', abstract='',
-            metadata=[], uoms=[]):
+                 metadata=None, uoms=None):
+        if metadata is None:
+            metadata = []
+        if uoms is None:
+            uoms = []
         basic.LiteralOutput.__init__(self, identifier, title=title, data_type=data_type, uoms=uoms)
         self.abstract = abstract
         self.metadata = metadata

--- a/pywps/inout/outputs.py
+++ b/pywps/inout/outputs.py
@@ -75,21 +75,20 @@ class BoundingBoxOutput(basic.BBoxInput):
 class ComplexOutput(basic.ComplexOutput):
     """
     :param identifier: The name of this output.
-    :param formats: Possible output formats for this output.
+    :param title: Readable form of the output name.
+    :param output_formats: List of supported
+            output formats for this output.
             Should be list of :class:`~Format` object.
-    :param output_format: Required format for this output.
-            Should be :class:`~Format` object.
-    :param encoding: The encoding of this input or requested for this output
-            (e.g., UTF-8).
+            The first format in the list will be used as the default.
+    :param abstract: Description of the output
     """
 
-    def __init__(self, identifier, title,  output_format=None,
-                 abstract='', supported_formats=None, metadata=[]):
+    def __init__(self, identifier, title,  output_formats=None,
+                 abstract='', metadata=[]):
 
         basic.ComplexOutput.__init__(self, identifier, title=title,
                                      abstract=abstract,
-                                     data_format=output_format,
-                                     supported_formats=supported_formats)
+                                     output_formats=output_formats)
         self.metadata = metadata
         self.as_reference = False
 

--- a/tests/process.py
+++ b/tests/process.py
@@ -12,25 +12,35 @@ sys.path.append(pywpsPath)
 
 import unittest
 
-from pywps.process import Process
-from pywps.process.inout.standards import LiteralLengthInput
-from pywps.process.inout.standards import BBoxInput
-from pywps.process.inout.standards import ComplexVectorInput
+from pywps import Process
+from pywps.inout import LiteralInput
+from pywps.inout import BoundingBoxInput
+from pywps.inout import ComplexInput
 
 class ProcessTestCase(unittest.TestCase):
 
-    def test_get_input_type(self):
-        """Test returning the proper input type"""
+    def test_get_input_title(self):
+        """Test returning the proper input title"""
 
         # configure
-        process = Process("process")
-        process.add_input(LiteralLengthInput())
-        process.add_input(BBoxInput())
-        process.add_input(ComplexVectorInput())
-        
-        self.assertEquals("literal",process.get_input_type("length"))
-        self.assertEquals("bbox",process.get_input_type("bbox"))
-        self.assertEquals("complex",process.get_input_type("vector"))
+        def donothing(*args, **kwargs):
+            pass
+        process = Process(donothing, "process", title="Process",
+                          inputs=[
+                              LiteralInput("length", title="Length"),
+                              BoundingBoxInput("bbox", title="BBox", crss=[]),
+                              ComplexInput("vector", title="Vector")
+                          ],
+                          outputs=[]
+        )
+        inputs = {
+            input.identifier: input.title
+            for input
+            in process.inputs
+        }
+        self.assertEquals("Length", inputs['length'])
+        self.assertEquals("BBox", inputs["bbox"])
+        self.assertEquals("Vector", inputs["vector"])
 
 if __name__ == "__main__":
    suite = unittest.TestLoader().loadTestsFromTestCase(ProcessTestCase)

--- a/tests/processes/__init__.py
+++ b/tests/processes/__init__.py
@@ -1,8 +1,8 @@
-from pywps.process import Process
-from pywps.process.inout.standards import LiteralLengthInput
+from pywps import Process
+from pywps.inout import LiteralInput
 
 class SimpleProcess(Process):
     identifier = "simpleprocess"
 
     def __init__(self):
-        self.add_input(LiteralLengthInput())
+        self.add_input(LiteralInput())

--- a/tests/test_assync.py
+++ b/tests/test_assync.py
@@ -6,37 +6,53 @@ from tests.common import client_for, assert_response_accepted
 
 
 def create_sleep():
-    
+
     def sleep(request, response):
         seconds = request.inputs['seconds']
         assert type(seconds) is type(1.0)
-        
+
         step = seconds / 10
         for i in range(10):
             # How is status working in version 4 ?
             #self.status.set("Waiting...", i * 10)
             time.sleep(step)
-        
+
         response.outputs['finished'] = "True"
         return response
-    
-        return Process(handler=sleep,
-                   inputs=[LiteralInput('seconds', mimeType='text/xml')],
-                   outputs=[LiteralOutput('finished', mimeType='text/xml')])
+
+    return Process(handler=sleep,
+                   identifier='sleep',
+                   title='Sleep',
+                   inputs=[
+                       LiteralInput('seconds', title='Seconds', data_type='float')
+                   ],
+                   outputs=[
+                       LiteralOutput('finished', title='Finished', data_type='boolean')
+                   ]
+    )
 
 
 class ExecuteTest(unittest.TestCase):
-            
+
     def test_assync(self):
         client = client_for(Service(processes=[create_sleep()]))
         request_doc = WPS.Execute(
             OWS.Identifier('sleep'),
             WPS.DataInputs(
-                WPS.Input(OWS.Identifier('seconds'), 120)))
+                WPS.Input(
+                    OWS.Identifier('seconds'),
+                    WPS.Data(
+                        WPS.LiteralData(
+                            "120"
+                        )
+                    )
+                )
+            ),
+            version="1.0.0"
+        )
         resp = client.post_xml(doc=request_doc)
-        assert_response_accepted(resp) 
-        
-        # To Do: 
+        assert_response_accepted(resp)
+
+        # To Do:
         # . extract the status URL from the response
         # . send a status request
-    

--- a/tests/test_describe.py
+++ b/tests/test_describe.py
@@ -184,8 +184,8 @@ class OutputDescriptionTest(unittest.TestCase):
         doc = literal.describe_xml()
         [output] = xpath_ns(doc, '/Output')
         [identifier] = xpath_ns(doc, '/Output/ows:Identifier')
-        [data_type] = xpath_ns(doc, '/Output/LiteralData/ows:DataType')
-        [uoms] = xpath_ns(doc, '/Output/LiteralData/UOMs')
+        [data_type] = xpath_ns(doc, '/Output/LiteralOutput/ows:DataType')
+        [uoms] = xpath_ns(doc, '/Output/LiteralOutput/UOMs')
         [default_uom] = xpath_ns(uoms, './Default/ows:UOM')
         supported_uoms = xpath_ns(uoms, './Supported/ows:UOM')
         
@@ -198,7 +198,7 @@ class OutputDescriptionTest(unittest.TestCase):
         assert len(supported_uoms) == 1
 
     def test_complex_output(self):
-        complexo = ComplexOutput('complex', 'Complex foo', Format('GML'))
+        complexo = ComplexOutput('complex', 'Complex foo', [Format('GML')])
         doc = complexo.describe_xml()
         [outpt] = xpath_ns(doc, '/Output')
         [default] = xpath_ns(doc, '/Output/ComplexOutput/Default/Format/MimeType')
@@ -212,10 +212,9 @@ class OutputDescriptionTest(unittest.TestCase):
         bbox = BoundingBoxOutput('bbox', 'BBox foo',
                 crss=["EPSG:4326"])
         doc = bbox.describe_xml()
-        [inpt] = xpath_ns(doc, '/Output')
+        [outpt] = xpath_ns(doc, '/Output')
         [default_crs] = xpath_ns(doc, './BoundingBoxOutput/Default/CRS')
         supported = xpath_ns(doc, './BoundingBoxOutput/Supported/CRS')
-        assert inpt.attrib['minOccurs'] == '1'
         assert default_crs.text == 'EPSG:4326'
         assert len(supported) == 1
 

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -14,8 +14,8 @@ class ExceptionsTest(unittest.TestCase):
     def test_invalid_parameter_value(self):
         resp = self.client.get('?service=wms')
         exception_el = resp.xpath('/ows:ExceptionReport/ows:Exception')[0]
-        assert exception_el.attrib['exceptionCode'] == 'OperationNotSupported'
-        assert resp.status_code == 501
+        assert exception_el.attrib['exceptionCode'] == 'InvalidParameterValue'
+        assert resp.status_code == 400
         assert resp.headers['Content-Type'] == 'text/xml'
 
     def test_missing_parameter_value(self):
@@ -28,7 +28,8 @@ class ExceptionsTest(unittest.TestCase):
     def test_missing_request(self):
         resp = self.client.get("?service=wps")
         exception_el = resp.xpath('/ows:ExceptionReport/ows:Exception/ows:ExceptionText')[0]
-        assert exception_el.text == 'request'
+        # should mention something about a request
+        assert 'request' in exception_el.text
         assert resp.headers['Content-Type'] == 'text/xml'
 
     def test_bad_request(self):

--- a/tests/test_inout.py
+++ b/tests/test_inout.py
@@ -132,7 +132,7 @@ class ComplexOutputTest(unittest.TestCase):
         tmp_dir = tempfile.mkdtemp()
         data_format = get_data_format()
         self.complex_out = ComplexOutput(identifier="complexinput", workdir=tmp_dir,
-                                         data_format=data_format)
+                                         supported_formats=[data_format])
 
     def test_contruct(self):
         self.assertIsInstance(self.complex_out, ComplexOutput)


### PR DESCRIPTION
The [Centroids](https://github.com/PyWPS/pywps-4-demo/blob/master/processes/centroids.py#L11) and other examples use the following constructor format for ComplexOutput: 
   
    ComplexOutput('out', 'Referenced Output', [Format('JSON')])

This constructor was passing the list of formats to `default_format`. In [other parts](https://github.com/jachym/pywps-4/blob/master/pywps/inout/outputs.py#L101) of the code the first element of the `supported_formats` was used as the default format. 
This first element was not defined if supported formats was not explicitly passed (as in the Centroids example). 

I thought passing a list of supported formats, from which the first is the default, was a convenient and consistent api call. So I changed it accordingly. Please let me know if this is the intended/expected behaviour. 
