### PR TITLE
pep8 formatting

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,6 +1,6 @@
 # encoding: utf-8
 
-import sys, os
+import sys
 
 project = u'PyWPS'
 copyright = u'2013, Jachym Cepicky'
@@ -21,8 +21,10 @@ htmlhelp_basename = 'PyWPSdoc'
 class Mock(object):
     def __init__(self, *args, **kwargs):
         pass
+
     def __call__(self, *args, **kwargs):
         return Mock()
+
     @classmethod
     def __getattr__(cls, name):
         if name in ('__file__', '__path__'):

--- a/pywps/__init__.py
+++ b/pywps/__init__.py
@@ -4,7 +4,7 @@ working with list of processes, executing them and redirecting OGC WPS
 responses back to client.
 """
 # Author:    Alex Morega & Calin Ciociu
-#            
+#
 # License:
 #
 # Web Processing Service implementation
@@ -16,10 +16,10 @@ responses back to client.
 # rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
 # sell copies of the Software, and to permit persons to whom the Software is
 # furnished to do so, subject to the following conditions:
-# 
+#
 # The above copyright notice and this permission notice shall be included in
 # all copies or substantial portions of the Software.
-# 
+#
 # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 # IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -29,6 +29,7 @@ responses back to client.
 # IN THE SOFTWARE.
 
 import os
+
 from lxml.builder import ElementMaker
 
 
@@ -77,13 +78,13 @@ OGCUNIT = {
     'unity': 'urn:ogc:def:uom:OGC:1.0:unity'
 }
 
-from pywps.app import Process, Service, WPSRequest
-from pywps.app.WPSRequest import get_inputs_from_xml, get_output_from_xml
-from pywps.inout.inputs import LiteralInput, ComplexInput, BoundingBoxInput
-from pywps.inout.outputs import LiteralOutput, ComplexOutput, BoundingBoxOutput
-from pywps.inout.formats import Format, FORMATS, get_format
-from pywps.inout import UOM
+# namespace imports, ignore not used warning
+from pywps.app import Process, Service, WPSRequest  # noqa
+from pywps.app.WPSRequest import get_inputs_from_xml, get_output_from_xml  # noqa
+from pywps.inout.inputs import LiteralInput, ComplexInput, BoundingBoxInput  # noqa
+from pywps.inout.outputs import LiteralOutput, ComplexOutput, BoundingBoxOutput  # noqa
+from pywps.inout.formats import Format, FORMATS, get_format  # noqa
+from pywps.inout import UOM  # noqa
 
 if __name__ == "__main__":
     pass
-

--- a/pywps/_compat.py
+++ b/pywps/_compat.py
@@ -1,7 +1,7 @@
 """ Compatibility support for Python 2 and 3 """
 
 # Author:    Alex Morega (?)
-#            
+#
 # License:
 #
 # Web Processing Service implementation
@@ -13,10 +13,10 @@
 # rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
 # sell copies of the Software, and to permit persons to whom the Software is
 # furnished to do so, subject to the following conditions:
-# 
+#
 # The above copyright notice and this permission notice shall be included in
 # all copies or substantial portions of the Software.
-# 
+#
 # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 # IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -36,5 +36,6 @@ if PY2:
 
 else:
     text_type = str
-    from io import StringIO
-    from enum import Enum
+    # used in imports, no need to check for usage
+    from io import StringIO  # noqa
+    from enum import Enum  # noqa

--- a/pywps/app/Process.py
+++ b/pywps/app/Process.py
@@ -1,6 +1,7 @@
 import os
 from uuid import uuid4
 import sys
+
 from pywps import WPS, OWS, E
 from pywps.app.WPSResponse import WPSResponse
 from pywps.exceptions import StorageNotSupported, OperationNotSupported
@@ -59,8 +60,8 @@ class Process(object):
         if self.abstract:
             doc.append(OWS.Abstract(self.abstract))
         # TODO: See Table 32 Metadata in OGC 06-121r3
-        #for m in self.metadata:
-        #    doc.append(OWS.Metadata(m))
+        # for m in self.metadata:
+        #     doc.append(OWS.Metadata(m))
         if self.profile:
             doc.append(OWS.Profile(self.profile))
         if self.wsdl:

--- a/pywps/app/WPSResponse.py
+++ b/pywps/app/WPSResponse.py
@@ -1,7 +1,9 @@
 import os
-from lxml import etree
 import time
-from werkzeug.wrappers import Request
+
+from lxml import etree
+from werkzeug.wrappers import Request, HTTPException
+
 from pywps import WPS, OWS
 from pywps.app.basic import xml_response
 from pywps.exceptions import NoApplicableCode
@@ -91,7 +93,7 @@ class WPSResponse(object):
 
     def _construct_doc(self):
         doc = WPS.ExecuteResponse()
-        doc.attrib['{http://www.w3.org/2001/XMLSchema-instance}schemaLocation'] = 'http://www.opengis.net/wps/1.0.0 http://schemas.opengis.net/wps/1.0.0/wpsDescribeProcess_response.xsd'
+        doc.attrib['{http://www.w3.org/2001/XMLSchema-instance}schemaLocation'] = 'http://www.opengis.net/wps/1.0.0 http://schemas.opengis.net/wps/1.0.0/wpsDescribeProcess_response.xsd'  # noqa
         doc.attrib['service'] = 'WPS'
         doc.attrib['version'] = '1.0.0'
         doc.attrib['{http://www.w3.org/XML/1998/namespace}lang'] = 'en-CA'
@@ -113,8 +115,8 @@ class WPSResponse(object):
         if self.process.abstract:
             process_doc.append(OWS.Abstract(self.process.abstract))
         # TODO: See Table 32 Metadata in OGC 06-121r3
-        #for m in self.process.metadata:
-        #    process_doc.append(OWS.Metadata(m))
+        # for m in self.process.metadata:
+        #     process_doc.append(OWS.Metadata(m))
         if self.process.profile:
             process_doc.append(OWS.Profile(self.process.profile))
         if self.process.wsdl:

--- a/pywps/app/__init__.py
+++ b/pywps/app/__init__.py
@@ -1,6 +1,7 @@
-from pywps.app.Process import Process
-from pywps.app.Service import Service
-from pywps.app.WPSResponse import WPSResponse
-from pywps.app.WPSRequest import WPSRequest
-from pywps.app.WPSRequest import get_inputs_from_xml
-from pywps.app.WPSRequest import get_output_from_xml
+# flatten namespace
+from pywps.app.Process import Process  # noqa
+from pywps.app.Service import Service  # noqa
+from pywps.app.WPSResponse import WPSResponse  # noqa
+from pywps.app.WPSRequest import WPSRequest  # noqa
+from pywps.app.WPSRequest import get_inputs_from_xml  # noqa
+from pywps.app.WPSRequest import get_output_from_xml  # noqa

--- a/pywps/app/basic.py
+++ b/pywps/app/basic.py
@@ -1,6 +1,7 @@
 import lxml
 from werkzeug.wrappers import Response
-from pywps import OWS, NAMESPACES, OGCUNIT
+
+from pywps import NAMESPACES
 
 
 def xpath_ns(el, path):

--- a/pywps/configuration.py
+++ b/pywps/configuration.py
@@ -2,7 +2,7 @@
 Reads the PyWPS configuration file
 """
 # Author:    Calin Ciociu
-#            
+#
 # License:
 #
 # Web Processing Service implementation
@@ -14,10 +14,10 @@ Reads the PyWPS configuration file
 # rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
 # sell copies of the Software, and to permit persons to whom the Software is
 # furnished to do so, subject to the following conditions:
-# 
+#
 # The above copyright notice and this permission notice shall be included in
 # all copies or substantial portions of the Software.
-# 
+#
 # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 # IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -127,7 +127,8 @@ def load_configuration(cfgfiles=None):
     if not cfgfiles:
         cfgfiles = _get_default_config_files_location()
 
-    if type(cfgfiles) != type(()):
+    if not isinstance(cfgfiles, tuple):
+        # config.read accepts a list of config files
         cfgfiles = (cfgfiles)
 
     loaded_files = config.read(cfgfiles)
@@ -135,6 +136,7 @@ def load_configuration(cfgfiles=None):
         print('Configuration file(s) {} loaded'.format(loaded_files))
     else:
         print('No configuration files loaded. Using default values.')
+
 
 def _get_default_config_files_location():
     """Get the locations of the standard configuration files. These are
@@ -155,27 +157,48 @@ def _get_default_config_files_location():
 
         # Windows or Unix
         if sys.platform == 'win32':
-            PYWPS_INSTALL_DIR = os.path.abspath(os.path.join(os.getcwd(), os.path.dirname(sys.argv[0])))
-            cfgfiles = (os.getenv("PYWPS_CFG"))
+            PYWPS_INSTALL_DIR = os.path.abspath(
+                os.path.join(
+                    os.getcwd(),
+                    os.path.dirname(sys.argv[0])
+                )
+            )
+            cfgfiles = os.getenv("PYWPS_CFG")
         else:
-            cfgfiles = (os.getenv("PYWPS_CFG"))
+            cfgfiles = os.getenv("PYWPS_CFG")
 
     # try to eastimate the default location
     else:
         # Windows or Unix
         if sys.platform == 'win32':
-            PYWPS_INSTALL_DIR = os.path.abspath(os.path.join(os.getcwd(), os.path.dirname(sys.argv[0])))
-            cfgfiles = (os.path.join(PYWPS_INSTALL_DIR, "pywps", "etc", "pywps.cfg"))
+            PYWPS_INSTALL_DIR = os.path.abspath(
+                os.path.join(
+                    os.getcwd(),
+                    os.path.dirname(sys.argv[0])
+                )
+            )
+            cfgfiles = os.path.join(
+                PYWPS_INSTALL_DIR,
+                "pywps",
+                "etc",
+                "pywps.cfg"
+            )
         else:
             homePath = os.getenv("HOME")
             if homePath:
-                cfgfiles = (os.path.join(pywps.__path__[0], "etc", "pywps.cfg"), "/etc/pywps.cfg",
-                    os.path.join(os.getenv("HOME"), ".pywps.cfg"))
+                cfgfiles = (
+                    os.path.join(pywps.__path__[0], "etc", "pywps.cfg"),
+                    "/etc/pywps.cfg",
+                    os.path.join(os.getenv("HOME"), ".pywps.cfg")
+                )
             else:
-                cfgfiles = (os.path.join(pywps.__path__[0], "etc",
-                            "pywps.cfg"), "/etc/pywps.cfg")
+                cfgfiles = (
+                    os.path.join(pywps.__path__[0], "etc", "pywps.cfg"),
+                    "/etc/pywps.cfg"
+                )
 
     return cfgfiles
+
 
 def get_size_mb(mbsize):
     """Get real size of given obeject

--- a/pywps/exceptions.py
+++ b/pywps/exceptions.py
@@ -6,7 +6,7 @@ Based on OGC OWS, WPS and
 http://lists.opengeospatial.org/pipermail/wps-dev/2013-October/000335.html
 """
 # Author:    Alex Morega & Calin Ciociu
-#            
+#
 # License:
 #
 # Web Processing Service implementation
@@ -18,10 +18,10 @@ http://lists.opengeospatial.org/pipermail/wps-dev/2013-October/000335.html
 # rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
 # sell copies of the Software, and to permit persons to whom the Software is
 # furnished to do so, subject to the following conditions:
-# 
+#
 # The above copyright notice and this permission notice shall be included in
 # all copies or substantial portions of the Software.
-# 
+#
 # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 # IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -30,12 +30,11 @@ http://lists.opengeospatial.org/pipermail/wps-dev/2013-October/000335.html
 # FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
 # IN THE SOFTWARE.
 
-from werkzeug.exceptions import HTTPException, BadRequest, MethodNotAllowed
+import logging
+
+from werkzeug.exceptions import HTTPException
 from werkzeug._compat import text_type
 from werkzeug.utils import escape
-from werkzeug.http import HTTP_STATUS_CODES
-
-import logging
 
 
 class NoApplicableCode(HTTPException):
@@ -69,7 +68,9 @@ class NoApplicableCode(HTTPException):
     def get_description(self, environ=None):
         """Get the description."""
         if self.description:
-            return '''<ows:ExceptionText>%s</ows:ExceptionText>''' % escape(self.description)
+            return '''<ows:ExceptionText>%s</ows:ExceptionText>''' % escape(
+                self.description
+            )
         else:
             return ''
 
@@ -77,7 +78,7 @@ class NoApplicableCode(HTTPException):
         """Get the XML body."""
         return text_type((
             u'<?xml version="1.0" encoding="UTF-8"?>\n'
-            u'<ows:ExceptionReport xmlns:ows="http://www.opengis.net/ows/1.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.opengis.net/ows/1.1 ../../../ows/1.1.0/owsExceptionReport.xsd" version="1.0.0">'
+            u'<ows:ExceptionReport xmlns:ows="http://www.opengis.net/ows/1.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.opengis.net/ows/1.1 ../../../ows/1.1.0/owsExceptionReport.xsd" version="1.0.0">'  # noqa
             u'<ows:Exception exceptionCode="%(name)s" locator="%(locator)s" >'
             u'%(description)s'
             u'</ows:Exception>'

--- a/pywps/inout/__init__.py
+++ b/pywps/inout/__init__.py
@@ -1,4 +1,5 @@
-from pywps.inout.inputs import LiteralInput, ComplexInput, BoundingBoxInput
-from pywps.inout.outputs import LiteralOutput, ComplexOutput, BoundingBoxOutput
-from pywps.inout.formats import Format, FORMATS, get_format
-from pywps.inout.basic import UOM
+# flatten namespace
+from pywps.inout.inputs import LiteralInput, ComplexInput, BoundingBoxInput  # noqa
+from pywps.inout.outputs import LiteralOutput, ComplexOutput, BoundingBoxOutput  # noqa
+from pywps.inout.formats import Format, FORMATS, get_format  # noqa
+from pywps.inout.basic import UOM  # noqa

--- a/pywps/inout/formats/__init__.py
+++ b/pywps/inout/formats/__init__.py
@@ -39,6 +39,7 @@ FORMATS = _FORMATS(
     _FORMAT('application/x-ogc-wms; version=1.0.0', '.xml', None)
 )
 
+
 def _get_mimetypes():
     """Add FORMATS to system wide mimetypes
     """
@@ -75,7 +76,6 @@ class Format(object):
         self.schema = schema
         self.validate = validate
         self.extension = extension
-
 
     @property
     def mime_type(self):
@@ -131,13 +131,15 @@ class Format(object):
         """
         self._schema = schema
 
-
     def same_as(self, frmt):
         """Check input frmt, if it seems to be the same as self
         """
-        return frmt.mime_type == self.mime_type and\
-               frmt.encoding == self.encoding and\
-               frmt.schema == self.schema
+        is_same = (
+            frmt.mime_type == self.mime_type
+            and frmt.encoding == self.encoding
+            and frmt.schema == self.schema
+        )
+        return is_same
 
     def describe_xml(self):
         """Return describe process response element
@@ -148,7 +150,6 @@ class Format(object):
             elmar.MimeType(self.mime_type)
         )
 
-
         if self.encoding:
             doc.append(elmar.Encoding(self.encoding))
 
@@ -156,6 +157,7 @@ class Format(object):
             doc.append(elmar.Schema(self.schema))
 
         return doc
+
 
 def get_format(frmt, validator=None):
     """Return Format instance based on given pywps.inout.FORMATS keyword
@@ -167,7 +169,7 @@ def get_format(frmt, validator=None):
     if frmt in FORMATS._asdict():
         formatdef = FORMATS._asdict()[frmt]
         outfrmt = Format(**formatdef._asdict())
-        outfrmt.validate=validator
+        outfrmt.validate = validator
         return outfrmt
     else:
         return Format('None', validate=validator)

--- a/pywps/inout/formats/lists.py
+++ b/pywps/inout/formats/lists.py
@@ -27,4 +27,3 @@ FORMATS = _FORMATS(
     _FORMAT('application/x-ogc-wms; version=1.1.0', '.xml', None),
     _FORMAT('application/x-ogc-wms; version=1.0.0', '.xml', None)
 )
-

--- a/pywps/inout/inputs.py
+++ b/pywps/inout/inputs.py
@@ -1,7 +1,9 @@
+from copy import deepcopy
+
 from pywps import configuration, E, OWS, WPS, OGCTYPE, NAMESPACES
 from pywps.inout import basic
-from copy import deepcopy
 from pywps.validator.mode import MODE
+
 
 class BoundingBoxInput(basic.BBoxInput):
     """
@@ -86,13 +88,13 @@ class ComplexInput(basic.ComplexInput):
     """
     :param identifier: The name of this input.
     :param allowed_formats: Allowed formats for this input. Should be a list of
-                    one or more :class:`~Format` objects. First one is assumed to 
-                    be the default. 
+                    one or more :class:`~Format` objects. First one is assumed to
+                    be the default.
     """
 
     def __init__(self, identifier, title, supported_formats=None,
                  data_format=None, abstract='', metadata=[], min_occurs=1,
-                 max_occurs=1, as_reference=False, mode=MODE.NONE): 
+                 max_occurs=1, as_reference=False, mode=MODE.NONE):
 
         if metadata is None:
             metadata = []
@@ -145,7 +147,7 @@ class ComplexInput(basic.ComplexInput):
         )
 
         return doc
-    
+
     def execute_xml(self):
         """Render Execute response XML node
 
@@ -200,8 +202,7 @@ class ComplexInput(basic.ComplexInput):
                 complex_doc.attrib['schema'] = self.data_format.schema
         doc.append(complex_doc)
         return doc
-    
-    
+
     def clone(self):
         """Create copy of yourself
         """
@@ -315,7 +316,6 @@ class LiteralInput(basic.LiteralInput):
             literal_doc.attrib['uom'] = self.uom
         doc.append(literal_doc)
         return doc
-
 
     def clone(self):
         """Create copy of yourself

--- a/pywps/inout/literaltypes.py
+++ b/pywps/inout/literaltypes.py
@@ -1,9 +1,16 @@
-from abc import ABCMeta, abstractmethod, abstractproperty
 # TODO cover with tests
 """Literaltypes are used for LiteralInputs, to make sure, input data are OK
 """
 
-LITERAL_DATA_TYPES = ['float', 'boolean', 'measure', 'angleList', 'scale', 'angle', 'integerList', 'positiveInteger', 'anyURI', 'positiveIntegerList', 'string', 'lengthOrAngle', 'gridLength', 'measureList', 'lengthList', 'integer', 'gridLengthList', 'scaleList', 'timeList', 'nonNegativeInteger', 'length', 'time']
+LITERAL_DATA_TYPES = [
+    'float', 'boolean', 'measure', 'angleList',
+    'scale', 'angle', 'integerList', 'positiveInteger',
+    'anyURI', 'positiveIntegerList', 'string',
+    'lengthOrAngle', 'gridLength', 'measureList',
+    'lengthList', 'integer', 'gridLengthList',
+    'scaleList', 'timeList', 'nonNegativeInteger',
+    'length', 'time'
+]
 
 
 def convert_boolean(inpt):
@@ -35,6 +42,7 @@ def convert_boolean(inpt):
             val = True
     return val
 
+
 def convert_float(inpt):
     """Return float value from inpt
 
@@ -44,6 +52,7 @@ def convert_float(inpt):
 
     return float(inpt)
 
+
 def convert_integer(inpt):
     """Return integer value from input inpt
 
@@ -52,6 +61,7 @@ def convert_integer(inpt):
     """
 
     return int(float(inpt))
+
 
 def convert_string(inpt):
     """Return string value from input lit_input

--- a/pywps/inout/outputs.py
+++ b/pywps/inout/outputs.py
@@ -1,10 +1,10 @@
+import lxml.etree as etree
+
 from pywps._compat import text_type
 from pywps import E, WPS, OWS, OGCTYPE, NAMESPACES
 from pywps.inout import basic
 from pywps.inout.storage import FileStorage
-from pywps.inout.formats import Format
 from pywps.validator.mode import MODE
-import lxml.etree as etree
 
 
 class BoundingBoxOutput(basic.BBoxInput):
@@ -175,7 +175,6 @@ class ComplexOutput(basic.ComplexOutput):
         """
         doc = WPS.Data()
 
-
         if self.data is None:
             complex_doc = WPS.ComplexData()
         else:
@@ -205,14 +204,14 @@ class LiteralOutput(basic.LiteralOutput):
             Should be :class:`~String` object.
     """
 
-    def __init__(self, identifier, title, data_type='string', abstract='',
-            metadata=[], uoms=[], mode=MODE.SIMPLE):
+    def __init__(self, identifier, title, data_type='string',
+                 abstract='', metadata=[], uoms=[], mode=MODE.SIMPLE):
         if metadata is None:
             metadata = []
         if uoms is None:
             uoms = []
         basic.LiteralOutput.__init__(self, identifier, title=title,
-                data_type=data_type, uoms=uoms, mode=mode)
+                                     data_type=data_type, uoms=uoms, mode=mode)
         self.abstract = abstract
         self.metadata = metadata
 
@@ -260,7 +259,6 @@ class LiteralOutput(basic.LiteralOutput):
             doc.append(OWS.Abstract(self.abstract))
 
         return doc
-
 
     def execute_xml(self):
         doc = WPS.Output(

--- a/pywps/inout/storage.py
+++ b/pywps/inout/storage.py
@@ -1,13 +1,19 @@
-from abc import ABCMeta, abstractmethod, abstractproperty
+from abc import ABCMeta, abstractmethod
 import os
+import shutil
+import tempfile
+import math
+
 from pywps._compat import PY2
-from pywps.exceptions import NotEnoughStorage, NoApplicableCode
+from pywps.exceptions import NotEnoughStorage
 from pywps import configuration as config
 
 
 class STORE_TYPE:
     PATH = 0
 # TODO: cover with tests
+
+
 class StorageAbstract(object):
     """Data storage abstract class
     """
@@ -24,6 +30,7 @@ class StorageAbstract(object):
             url - url, where the data can be downloaded
         """
         pass
+
 
 class DummyStorage(StorageAbstract):
     """Dummy empty storage implementation, does nothing
@@ -78,7 +85,6 @@ class FileStorage(StorageAbstract):
         )
 
     def store(self, output):
-        import shutil, tempfile, math
 
         file_name = output.file
 

--- a/pywps/validator/__init__.py
+++ b/pywps/validator/__init__.py
@@ -1,10 +1,6 @@
 """Validatating functions for various inputs
 """
-from collections import namedtuple
 from pywps.validator.complexvalidator import validategml, validateshapefile, validategeojson, validategeotiff
-from pywps.validator.literalvalidator import validate_anyvalue, validate_allowed_values
-import logging
-from pywps.validator.mode import MODE
 from pywps.validator.base import emptyvalidator
 
 

--- a/pywps/validator/base.py
+++ b/pywps/validator/base.py
@@ -1,5 +1,6 @@
 from pywps.validator.mode import MODE
 
+
 def emptyvalidator(data_input, mode):
     """Empty validator will return always false for security reason
     """
@@ -8,5 +9,3 @@ def emptyvalidator(data_input, mode):
         return True
     else:
         return False
-
-

--- a/pywps/validator/complexvalidator.py
+++ b/pywps/validator/complexvalidator.py
@@ -1,7 +1,7 @@
 """Validator classes are used for ComplexInputs, to validate the content
 """
 # Author:    Jachym Cepicky
-#            
+#
 # License:
 #
 # Web Processing Service implementation
@@ -13,10 +13,10 @@
 # rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
 # sell copies of the Software, and to permit persons to whom the Software is
 # furnished to do so, subject to the following conditions:
-# 
+#
 # The above copyright notice and this permission notice shall be included in
 # all copies or substantial portions of the Software.
-# 
+#
 # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 # IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -25,10 +25,12 @@
 # FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
 # IN THE SOFTWARE.
 
-from pywps.validator.mode import MODE
-from pywps.inout.formats.lists import FORMATS
 import mimetypes
 import os
+
+from pywps.validator.mode import MODE
+from pywps.inout.formats.lists import FORMATS
+
 
 def validategml(data_input, mode):
     """GML validation example
@@ -46,12 +48,11 @@ def validategml(data_input, mode):
     >>> fake_input.data_format = fake_data_format()
     >>> validategml(fake_input, MODE.SIMPLE)
     True
-    """
+    """  # noqa
     passed = False
 
     if mode >= MODE.NONE:
         passed = True
-    import sys
 
     if mode >= MODE.SIMPLE:
 
@@ -83,10 +84,11 @@ def validategml(data_input, mode):
             gmlschema_doc = etree.parse(urlopen(schema_url))
             gmlschema = etree.XMLSchema(gmlschema_doc)
             passed = gmlschema.validate(etree.parse(data_input.stream))
-        except Exception as e:
+        except Exception:
             passed = False
 
     return passed
+
 
 def validategeojson(data_input, mode):
     """GeoJSON validation example
@@ -103,7 +105,7 @@ def validategeojson(data_input, mode):
     >>> fake_input.data_format = fake_data_format()
     >>> validategeojson(fake_input, MODE.SIMPLE)
     True
-    """
+    """  # noqa
     passed = False
 
     if mode >= MODE.NONE:
@@ -157,6 +159,7 @@ def validategeojson(data_input, mode):
 
     return passed
 
+
 def validateshapefile(data_input, mode):
     """ESRI Shapefile validation example
 
@@ -194,6 +197,7 @@ def validateshapefile(data_input, mode):
 
     return passed
 
+
 def validategeotiff(data_input, mode):
     """GeoTIFF validation example
     """
@@ -219,6 +223,7 @@ def validategeotiff(data_input, mode):
 
     return passed
 
+
 def _get_schemas_home():
     """Get path to schemas directory
     """
@@ -233,7 +238,6 @@ def _get_schemas_home():
 if __name__ == "__main__":
     import doctest
 
-    import os
     from pywps.wpsserver import temp_dir
 
     with temp_dir() as tmp:

--- a/pywps/validator/literalvalidator.py
+++ b/pywps/validator/literalvalidator.py
@@ -1,7 +1,7 @@
 """ Validator classes used for LiteralInputs
 """
 # Author:    Jachym Cepicky
-#            
+#
 # License:
 #
 # Web Processing Service implementation
@@ -13,10 +13,10 @@
 # rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
 # sell copies of the Software, and to permit persons to whom the Software is
 # furnished to do so, subject to the following conditions:
-# 
+#
 # The above copyright notice and this permission notice shall be included in
 # all copies or substantial portions of the Software.
-# 
+#
 # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 # IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -25,8 +25,9 @@
 # FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
 # IN THE SOFTWARE.
 
-from pywps.validator.mode import MODE
 from collections import namedtuple
+
+from pywps.validator.mode import MODE
 
 _ALLOWEDVALUETYPE = namedtuple('ALLOWEDVALUETYPE', 'VALUE, RANGE')
 _RANGELCLOSURETYPE = namedtuple('RANGECLOSURETYPE', 'OPEN, CLOSED,'
@@ -34,6 +35,7 @@ _RANGELCLOSURETYPE = namedtuple('RANGECLOSURETYPE', 'OPEN, CLOSED,'
 
 ALLOWEDVALUETYPE = _ALLOWEDVALUETYPE(0, 1)
 RANGECLOSURETYPE = _RANGELCLOSURETYPE(0, 1, 2, 3)
+
 
 class AllowedValue:
     """Allowed value parameters
@@ -49,6 +51,7 @@ class AllowedValue:
         self.maxval = maxval
         self.spacing = spacing
         self.range_closure = range_closure
+
 
 def validate_anyvalue(data_input, mode):
     """Just placeholder, anyvalue is always valid
@@ -98,7 +101,7 @@ def _validate_range(interval, data):
         if interval.spacing:
             spacing = abs(interval.spacing)
             diff = data - interval.minval
-            passed = diff%spacing == 0
+            passed = diff % spacing == 0
         else:
             passed = True
 

--- a/pywps/validator/mode.py
+++ b/pywps/validator/mode.py
@@ -1,6 +1,7 @@
 """Validation modes
 """
 
+
 class MODE():
     """Validation mode enumeration
     """

--- a/pywps/wpsserver.py
+++ b/pywps/wpsserver.py
@@ -2,7 +2,7 @@
 Abstract Server class
 """
 # Author:    Alex Morega
-#            
+#
 # License:
 #
 # Web Processing Service implementation
@@ -14,10 +14,10 @@ Abstract Server class
 # rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
 # sell copies of the Software, and to permit persons to whom the Software is
 # furnished to do so, subject to the following conditions:
-# 
+#
 # The above copyright notice and this permission notice shall be included in
 # all copies or substantial portions of the Software.
-# 
+#
 # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 # IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -29,6 +29,7 @@ Abstract Server class
 from abc import abstractmethod, ABCMeta
 from contextlib import contextmanager
 import tempfile
+
 from unipath import Path
 
 
@@ -44,7 +45,7 @@ def temp_dir():
 class PyWPSServerAbstract(object):
     """General stub for the PyWPS Server class.
     """
-    
+
     __metaclass__ = ABCMeta
 
     route_base = '/'

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -4,14 +4,13 @@ import unittest
 from tests import test_capabilities
 from tests import test_describe
 from tests import test_execute
-from tests import test_exceptions
 from tests import test_inout
 from tests import test_literaltypes
-from tests import validator
 from tests import test_ows
 from tests import test_formats
 from tests.validator import test_complexvalidators
 from tests.validator import test_literalvalidators
+
 
 def load_tests(loader=None, tests=None, pattern=None):
     """Load tests

--- a/tests/common.py
+++ b/tests/common.py
@@ -1,11 +1,13 @@
+import logging
+
 import lxml.etree
 from werkzeug.test import Client
 from werkzeug.wrappers import BaseResponse
+
 from pywps import NAMESPACES
 
-import logging
-
 logging.disable(logging.CRITICAL)
+
 
 class WpsClient(Client):
 
@@ -40,8 +42,9 @@ def assert_response_accepted(resp):
     success = resp.xpath_text('/wps:ExecuteResponse'
                               '/wps:Status'
                               '/wps:ProcessAccepted')
-    assert success != None
+    assert success is not None
     # To Do: assert status URL is present
+
 
 def assert_process_started(resp):
     assert resp.status_code == 200

--- a/tests/process.py
+++ b/tests/process.py
@@ -2,20 +2,23 @@
 """
 
 import os
-import sys
-from io import StringIO
-from lxml import objectify
-
-pywpsPath = os.path.abspath(os.path.join(os.path.split(os.path.abspath(__file__))[0],".."))
-sys.path.insert(0,pywpsPath)
-sys.path.append(pywpsPath)
-
 import unittest
+import sys
+
+pywpsPath = os.path.abspath(
+    os.path.join(
+        os.path.split(os.path.abspath(__file__))[0],
+        ".."
+    )
+)
+sys.path.insert(0, pywpsPath)
+sys.path.append(pywpsPath)
 
 from pywps import Process
 from pywps.inout import LiteralInput
 from pywps.inout import BoundingBoxInput
 from pywps.inout import ComplexInput
+
 
 class ProcessTestCase(unittest.TestCase):
 
@@ -25,14 +28,14 @@ class ProcessTestCase(unittest.TestCase):
         # configure
         def donothing(*args, **kwargs):
             pass
-        process = Process(donothing, "process", title="Process",
+        process = Process(donothing, "process",
+                          title="Process",
                           inputs=[
                               LiteralInput("length", title="Length"),
                               BoundingBoxInput("bbox", title="BBox", crss=[]),
                               ComplexInput("vector", title="Vector")
                           ],
-                          outputs=[]
-        )
+                          outputs=[])
         inputs = {
             input.identifier: input.title
             for input
@@ -43,5 +46,5 @@ class ProcessTestCase(unittest.TestCase):
         self.assertEquals("Vector", inputs["vector"])
 
 if __name__ == "__main__":
-   suite = unittest.TestLoader().loadTestsFromTestCase(ProcessTestCase)
-   unittest.TextTestRunner(verbosity=4).run(suite)
+    suite = unittest.TestLoader().loadTestsFromTestCase(ProcessTestCase)
+    unittest.TextTestRunner(verbosity=4).run(suite)

--- a/tests/processes/__init__.py
+++ b/tests/processes/__init__.py
@@ -1,6 +1,7 @@
 from pywps import Process
 from pywps.inout import LiteralInput
 
+
 class SimpleProcess(Process):
     identifier = "simpleprocess"
 

--- a/tests/test_assync.py
+++ b/tests/test_assync.py
@@ -1,5 +1,7 @@
 import unittest
 import time
+import number
+
 from pywps import Service, Process, LiteralInput, LiteralOutput
 from pywps import WPS, OWS
 from tests.common import client_for, assert_response_accepted
@@ -9,12 +11,12 @@ def create_sleep():
 
     def sleep(request, response):
         seconds = request.inputs['seconds']
-        assert type(seconds) is type(1.0)
+        assert isinstance(seconds, number.Number)
 
         step = seconds / 10
         for i in range(10):
             # How is status working in version 4 ?
-            #self.status.set("Waiting...", i * 10)
+            # self.status.set("Waiting...", i * 10)
             time.sleep(step)
 
         response.outputs['finished'] = "True"
@@ -28,8 +30,7 @@ def create_sleep():
                    ],
                    outputs=[
                        LiteralOutput('finished', title='Finished', data_type='boolean')
-                   ]
-    )
+                   ])
 
 
 class ExecuteTest(unittest.TestCase):

--- a/tests/test_capabilities.py
+++ b/tests/test_capabilities.py
@@ -1,8 +1,9 @@
 import unittest
-import lxml.etree
+
 from pywps.app import Process, Service
 from pywps import WPS, OWS
 from tests.common import client_for
+
 
 class BadRequestTest(unittest.TestCase):
 
@@ -21,7 +22,7 @@ class BadRequestTest(unittest.TestCase):
         resp = client.get('?service=foo')
 
         exception = resp.xpath('/ows:ExceptionReport'
-                                '/ows:Exception')
+                               '/ows:Exception')
 
         assert resp.status_code == 400
         assert exception[0].attrib['exceptionCode'] == 'InvalidParameterValue'
@@ -36,8 +37,11 @@ class BadRequestTest(unittest.TestCase):
 class CapabilitiesTest(unittest.TestCase):
 
     def setUp(self):
-        def pr1(): pass
-        def pr2(): pass
+        def pr1():
+            pass
+
+        def pr2():
+            pass
         self.client = client_for(Service(processes=[Process(pr1, 'pr1', 'Process 1'), Process(pr2, 'pr2', 'Process 2')]))
 
     def check_capabilities_response(self, resp):
@@ -69,21 +73,19 @@ class CapabilitiesTest(unittest.TestCase):
     def test_get_bad_version(self):
         resp = self.client.get('?request=getcapabilities&service=wps&acceptversions=2001-123')
         exception = resp.xpath('/ows:ExceptionReport'
-                                '/ows:Exception')
+                               '/ows:Exception')
         assert resp.status_code == 400
         assert exception[0].attrib['exceptionCode'] == 'VersionNegotiationFailed'
 
     def test_post_bad_version(self):
-        acceptedVersions_doc = OWS.AcceptVersions(
-                OWS.Version('2001-123'))
+        acceptedVersions_doc = OWS.AcceptVersions(OWS.Version('2001-123'))
         request_doc = WPS.GetCapabilities(acceptedVersions_doc)
         resp = self.client.post_xml(doc=request_doc)
         exception = resp.xpath('/ows:ExceptionReport'
-                                '/ows:Exception')
+                               '/ows:Exception')
 
         assert resp.status_code == 400
         assert exception[0].attrib['exceptionCode'] == 'VersionNegotiationFailed'
-
 
 
 def load_tests(loader=None, tests=None, pattern=None):

--- a/tests/test_describe.py
+++ b/tests/test_describe.py
@@ -1,12 +1,11 @@
 import unittest
 from collections import namedtuple
+
 from pywps import Process, Service, LiteralInput, ComplexInput, BoundingBoxInput
 from pywps import LiteralOutput, ComplexOutput, BoundingBoxOutput
 from pywps import E, WPS, OWS, OGCTYPE, Format, NAMESPACES, OGCUNIT
 from pywps.inout.literaltypes import LITERAL_DATA_TYPES
 from pywps.app.basic import xpath_ns
-from pywps.inout.formats import Format
-
 from tests.common import client_for
 
 ProcessDescription = namedtuple('ProcessDescription', ['identifier', 'inputs'])
@@ -52,8 +51,11 @@ def get_describe_result(resp):
 class DescribeProcessTest(unittest.TestCase):
 
     def setUp(self):
-        def hello(request): pass
-        def ping(request): pass
+        def hello(request):
+            pass
+
+        def ping(request):
+            pass
         processes = [Process(hello, 'hello', 'Process Hello'), Process(ping, 'ping', 'Process Ping')]
         self.client = client_for(Service(processes=processes))
 
@@ -65,7 +67,7 @@ class DescribeProcessTest(unittest.TestCase):
 
     def test_get_request_zero_args(self):
         resp = self.client.get('?Request=DescribeProcess&version=1.0.0&service=wps')
-        assert resp.status_code == 400 # bad request, identifier is missing
+        assert resp.status_code == 400  # bad request, identifier is missing
 
     def test_get_request_nonexisting_process_args(self):
         resp = self.client.get('?Request=DescribeProcess&version=1.0.0&service=wps&identifier=NONEXISTINGPROCESS')
@@ -117,13 +119,15 @@ class DescribeProcessInputTest(unittest.TestCase):
         return result
 
     def test_one_literal_string_input(self):
-        def hello(request): pass
+        def hello(request):
+            pass
         hello_process = Process(hello, 'hello', 'Process Hello', inputs=[LiteralInput('the_name', 'Input name')])
         result = self.describe_process(hello_process)
         assert result.inputs == [('the_name', 'literal', 'string')]
 
     def test_one_literal_integer_input(self):
-        def hello(request): pass
+        def hello(request):
+            pass
         hello_process = Process(hello, 'hello',
                                 'Process Hello',
                                 inputs=[LiteralInput('the_number',
@@ -184,6 +188,7 @@ class InputDescriptionTest(unittest.TestCase):
         assert default_crs.text == 'EPSG:4326'
         assert len(supported) == 2
 
+
 class OutputDescriptionTest(unittest.TestCase):
 
     def test_literal_output(self):
@@ -195,7 +200,7 @@ class OutputDescriptionTest(unittest.TestCase):
         [uoms] = xpath_ns(doc, '/Output/LiteralOutput/UOMs')
         [default_uom] = xpath_ns(uoms, './Default/ows:UOM')
         supported_uoms = xpath_ns(uoms, './Supported/ows:UOM')
-        
+
         assert output is not None
         assert identifier.text == 'literal'
         assert data_type.attrib['{%s}reference' % NAMESPACES['ows']] == OGCTYPE['string']
@@ -217,7 +222,7 @@ class OutputDescriptionTest(unittest.TestCase):
 
     def test_bbox_output(self):
         bbox = BoundingBoxOutput('bbox', 'BBox foo',
-                crss=["EPSG:4326"])
+                                 crss=["EPSG:4326"])
         doc = bbox.describe_xml()
         [outpt] = xpath_ns(doc, '/Output')
         [default_crs] = xpath_ns(doc, './BoundingBoxOutput/Default/CRS')

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -1,9 +1,7 @@
 import unittest
-from pywps import Process, Service, WPS, OWS
-from pywps.app.basic import xpath_ns
-from tests.common import client_for
-import lxml.etree
 
+from pywps import Service
+from tests.common import client_for
 
 
 class ExceptionsTest(unittest.TestCase):
@@ -37,6 +35,7 @@ class ExceptionsTest(unittest.TestCase):
         exception_el = resp.xpath('/ows:ExceptionReport/ows:Exception')[0]
         assert exception_el.attrib['exceptionCode'] == 'InvalidParameterValue'
         assert resp.headers['Content-Type'] == 'text/xml'
+
 
 def load_tests(loader=None, tests=None, pattern=None):
     if not loader:

--- a/tests/test_formats.py
+++ b/tests/test_formats.py
@@ -3,9 +3,7 @@
 import unittest
 
 from pywps.inout.formats import Format, get_format, FORMATS
-from lxml import etree
 from pywps.app.basic import xpath_ns
-from pywps.validator.base import emptyvalidator
 
 
 class FormatsTest(unittest.TestCase):
@@ -63,7 +61,6 @@ class FormatsTest(unittest.TestCase):
         frmt2 = get_format('GML')
 
         self.assertTrue(frmt.same_as(frmt2))
-
 
 
 def load_tests(loader=None, tests=None, pattern=None):

--- a/tests/test_inout.py
+++ b/tests/test_inout.py
@@ -3,21 +3,19 @@
 import os
 import tempfile
 import unittest
+
 from pywps import Format
 from pywps.validator import get_validator
-from pywps import NAMESPACES
 from pywps.inout.basic import IOHandler, SOURCE_TYPE, DataTypeAbstract, SimpleHandler, BBoxInput, BBoxOutput, \
     ComplexInput, ComplexOutput, LiteralInput, LiteralOutput
-from pywps.inout import BoundingBoxInput as BoundingBoxInputXML
 from pywps._compat import StringIO, text_type
 from pywps.validator.base import emptyvalidator
-
-from lxml import etree
 
 
 def get_data_format(mime_type):
     return Format(mime_type=mime_type,
-    validate=get_validator(mime_type))
+                  validate=get_validator(mime_type))
+
 
 class IOHandlerTest(unittest.TestCase):
     """IOHandler test cases"""
@@ -43,7 +41,7 @@ class IOHandlerTest(unittest.TestCase):
         """Test all outputs"""
 
         self.assertEqual(source_type, self.iohandler.source_type,
-                          'Source type properly set')
+                         'Source type properly set')
 
         self.assertEqual(self._value, self.iohandler.data, 'Data obtained')
 
@@ -76,7 +74,6 @@ class IOHandlerTest(unittest.TestCase):
         self.skipTest('Memory object not implemented')
         self.assertEqual(stream_val, self.iohandler.memory_object,
                          'Memory object obtained')
-
 
     def test_data(self):
         """Test data input IOHandler"""
@@ -126,10 +123,11 @@ class ComplexInputTest(unittest.TestCase):
 
     def test_validator(self):
         self.assertEqual(self.complex_in.data_format.validate,
-                       get_validator('application/json')) 
+                         get_validator('application/json'))
         self.assertEqual(self.complex_in.validator,
                          get_validator('application/json'))
         frmt = get_data_format('application/json')
+
         def my_validate():
             return True
         frmt.validate = my_validate
@@ -140,7 +138,6 @@ class ComplexInputTest(unittest.TestCase):
 
     def test_data_format(self):
         self.assertIsInstance(self.complex_in.supported_formats[0], Format)
-
 
 
 class ComplexOutputTest(unittest.TestCase):
@@ -171,7 +168,6 @@ class ComplexOutputTest(unittest.TestCase):
                          get_validator('application/json'))
 
 
-
 class SimpleHandlerTest(unittest.TestCase):
     """SimpleHandler test cases"""
 
@@ -189,6 +185,7 @@ class SimpleHandlerTest(unittest.TestCase):
 
     def test_data_type(self):
         self.assertEqual(self.simple_handler.data_type.convert('1'), 1)
+
 
 class LiteralInputTest(unittest.TestCase):
     """LiteralInput test cases"""
@@ -218,6 +215,7 @@ class LiteralOutputTest(unittest.TestCase):
         self.literal_output.store = storage
         self.assertEqual(self.literal_output.store, storage)
 
+
 class BoxInputTest(unittest.TestCase):
     """BBoxInput test cases"""
 
@@ -245,6 +243,7 @@ class BoxOutputTest(unittest.TestCase):
         storage = Storage()
         self.bbox_out.store = storage
         self.assertEqual(self.bbox_out.store, storage)
+
 
 def load_tests(loader=None, tests=None, pattern=None):
     if not loader:

--- a/tests/test_literaltypes.py
+++ b/tests/test_literaltypes.py
@@ -1,7 +1,9 @@
 """Unit tests for IOs
 """
 import unittest
-from pywps.inout.literaltypes import *
+
+from pywps.inout.literaltypes import convert_integer, convert_string, convert_float, convert_boolean
+
 
 class ConvertorTest(unittest.TestCase):
     """IOHandler test cases"""

--- a/tests/validator/test_complexvalidators.py
+++ b/tests/validator/test_complexvalidators.py
@@ -1,18 +1,21 @@
 """Unit tests for complex validator
 """
 import unittest
-import sys
-from pywps.validator.complexvalidator import *
-from pywps.inout.formats import FORMATS
 import tempfile
 import os
 
+from pywps.validator.complexvalidator import validategeojson, validategeotiff, validategml, validateshapefile
+from pywps.validator.mode import MODE
+from pywps.inout.formats import FORMATS
+
 try:
-    import osgeo
+    # import check
+    import osgeo                # noqa
 except ImportError:
     WITH_GDAL = False
 else:
     WITH_GDAL = True
+
 
 def get_input(name, schema, mime_type):
 
@@ -20,6 +23,7 @@ def get_input(name, schema, mime_type):
         mimetype = 'text/plain'
         schema = None
         units = None
+
         def validate(self, data):
             return True
 
@@ -51,7 +55,6 @@ class ValidateTest(unittest.TestCase):
     def setUp(self):
         pass
 
-
     def tearDown(self):
         pass
 
@@ -80,7 +83,7 @@ class ValidateTest(unittest.TestCase):
         """Test ESRI Shapefile validator
         """
         shapefile_input = get_input('shp/point.shp.zip', None,
-                FORMATS.SHP.mime_type)
+                                    FORMATS.SHP.mime_type)
         self.assertTrue(validateshapefile(shapefile_input, MODE.NONE), 'NONE validation')
         self.assertTrue(validateshapefile(shapefile_input, MODE.SIMPLE), 'SIMPLE validation')
         if WITH_GDAL:
@@ -100,6 +103,7 @@ class ValidateTest(unittest.TestCase):
     def test_fail_validator(self):
         fake_input = get_input('point.xsd', 'point.xsd', FORMATS.SHP.mime_type)
         self.assertFalse(validategml(fake_input, MODE.SIMPLE), 'SIMPLE validation invalid')
+
 
 def load_tests(loader=None, tests=None, pattern=None):
     if not loader:

--- a/tests/validator/test_literalvalidators.py
+++ b/tests/validator/test_literalvalidators.py
@@ -1,14 +1,18 @@
 """Unit tests for literal validator
 """
 import unittest
-from pywps.validator.literalvalidator import *
+from pywps.validator.literalvalidator import (
+    validate_anyvalue, validate_allowed_values,
+    AllowedValue, ALLOWEDVALUETYPE, RANGECLOSURETYPE
+)
+from pywps.validator.mode import MODE
 
-def get_input(allowed_values, data = 1):
+
+def get_input(allowed_values, data=1):
 
     class FakeInput(object):
         data = 1
         data_type = 'data'
-
 
     fake_input = FakeInput()
     fake_input.data = data
@@ -28,7 +32,7 @@ class ValidateTest(unittest.TestCase):
 
     def test_anyvalue_validator(self):
         """Test anyvalue validator"""
-        inpt = get_input(allowed_values = None)
+        inpt = get_input(allowed_values=None)
         self.assertTrue(validate_anyvalue(inpt, MODE.NONE))
 
     def test_allowedvalues_values_validator(self):
@@ -37,7 +41,7 @@ class ValidateTest(unittest.TestCase):
         allowed_value.allowed_type = ALLOWEDVALUETYPE.VALUE
         allowed_value.value = 1
 
-        inpt = get_input(allowed_values = [allowed_value])
+        inpt = get_input(allowed_values=[allowed_value])
         self.assertTrue(validate_allowed_values(inpt, MODE.SIMPLE), 'Allowed value 1 allowed')
 
         inpt.data = 2
@@ -53,7 +57,7 @@ class ValidateTest(unittest.TestCase):
         allowed_value.spacing = 2
         allowed_value.range_closure = RANGECLOSURETYPE.OPEN
 
-        inpt = get_input(allowed_values = [allowed_value])
+        inpt = get_input(allowed_values=[allowed_value])
 
         inpt.data = 1
         self.assertTrue(validate_allowed_values(inpt, MODE.SIMPLE), 'Range OPEN closure')
@@ -92,7 +96,7 @@ class ValidateTest(unittest.TestCase):
         allowed_value2.allowed_type = ALLOWEDVALUETYPE.VALUE
         allowed_value2.value = 15
 
-        inpt = get_input(allowed_values = [allowed_value1, allowed_value2])
+        inpt = get_input(allowed_values=[allowed_value1, allowed_value2])
 
         inpt.data = 1
         self.assertTrue(validate_allowed_values(inpt, MODE.SIMPLE), 'Range OPEN closure')
@@ -102,7 +106,6 @@ class ValidateTest(unittest.TestCase):
 
         inpt.data = 13
         self.assertFalse(validate_allowed_values(inpt, MODE.SIMPLE), 'Out of range')
-
 
 
 def load_tests(loader=None, tests=None, pattern=None):

--- a/tox.ini
+++ b/tox.ini
@@ -22,3 +22,6 @@ commands=
 	# check first which version is installed "gdal-config --version"
 	pip install GDAL==1.10.0 --global-option=build_ext --global-option="-I/usr/include/gdal"
     python -m unittest tests
+
+[flake8]
+max-line-length = 132


### PR DESCRIPTION
I have formatted the code according to pep8 and removed unused imports. I used 132 as maximum line length (set in `tox.ini`). Lines with `  # noqa` are ignored (long lines that should be long, imports for namespace flattening). Code now gives no warnings when using flake8 (pep8 + pyflakes).
